### PR TITLE
Check the 'modified' option of the actual target buffer

### DIFF
--- a/lua/bufdelete/init.lua
+++ b/lua/bufdelete/init.lua
@@ -7,7 +7,7 @@ local M = {}
 -- Common kill function for bdelete and bwipeout
 local function buf_kill(kill_command, bufnr, force)
     -- If buffer is modified and force isn't true, print error and abort
-    if not force and bo.modified then
+    if not force and vim.api.nvim_buf_get_option(bufnr, "modified") then
         return api.nvim_err_writeln(
             string.format(
                 'No write since last change for buffer %d (set force to true to override)',


### PR DESCRIPTION
The current behavior is to check whether the current buffer is modified, rather than the target buffer. This causes problem when trying to close an unchanged buffer when the current buffer is changed (for instance, telescope prompt)