### PR TITLE
feat: change esc to act like cancel for change prompt

### DIFF
--- a/lua/bufdelete/init.lua
+++ b/lua/bufdelete/init.lua
@@ -40,7 +40,7 @@ local function buf_kill(range, force, wipeout)
 
     -- If force is disabled, check for modified buffers in range.
     if not force then
-        for bufnr, _ in pairs(target_buffers) do
+        for bufnr, buf in pairs(target_buffers) do
             -- If buffer is modified, prompt user for action.
             if bo[bufnr].modified then
                 api.nvim_echo({{
@@ -55,14 +55,16 @@ local function buf_kill(range, force, wipeout)
 
                 if choice == 's' or choice == 'S' then  -- Save changes to the buffer.
                     api.nvim_buf_call(bufnr, function() cmd.write() end)
-                elseif choice == 'c' or choice == 'C' then  -- Cancel, remove buffer from targets.
-                    target_buffers[bufnr] = nil
+                elseif choice == 'i' or choice == 'I' then  -- Ignore, force close
+				else
+					target_buffers[bufnr] = nil
                 end
 
                 -- Clear message area.
                 cmd.echo('""')
                 cmd.redraw()
             end
+
         end
     end
 

--- a/lua/bufdelete/init.lua
+++ b/lua/bufdelete/init.lua
@@ -55,8 +55,7 @@ local function buf_kill(range, force, wipeout)
 
                 if choice == 's' or choice == 'S' then  -- Save changes to the buffer.
                     api.nvim_buf_call(bufnr, function() cmd.write() end)
-                elseif choice == 'i' or choice == 'I' then  -- Ignore, force close
-                else
+                elseif choice ~= 'i' and choice ~= 'I' then  -- If not ignored, do not close
                     target_buffers[bufnr] = nil
                 end
 

--- a/lua/bufdelete/init.lua
+++ b/lua/bufdelete/init.lua
@@ -55,7 +55,7 @@ local function buf_kill(range, force, wipeout)
 
                 if choice == 's' or choice == 'S' then  -- Save changes to the buffer.
                     api.nvim_buf_call(bufnr, function() cmd.write() end)
-                elseif choice ~= 'i' and choice ~= 'I' then  -- If not ignored, do not close
+                elseif choice ~= 'i' and choice ~= 'I' then  -- If not ignored, remove buffer from targets.
                     target_buffers[bufnr] = nil
                 end
 

--- a/lua/bufdelete/init.lua
+++ b/lua/bufdelete/init.lua
@@ -56,8 +56,8 @@ local function buf_kill(range, force, wipeout)
                 if choice == 's' or choice == 'S' then  -- Save changes to the buffer.
                     api.nvim_buf_call(bufnr, function() cmd.write() end)
                 elseif choice == 'i' or choice == 'I' then  -- Ignore, force close
-				else
-					target_buffers[bufnr] = nil
+                else
+                    target_buffers[bufnr] = nil
                 end
 
                 -- Clear message area.

--- a/lua/bufdelete/init.lua
+++ b/lua/bufdelete/init.lua
@@ -40,7 +40,7 @@ local function buf_kill(range, force, wipeout)
 
     -- If force is disabled, check for modified buffers in range.
     if not force then
-        for bufnr, buf in pairs(target_buffers) do
+        for bufnr, _ in pairs(target_buffers) do
             -- If buffer is modified, prompt user for action.
             if bo[bufnr].modified then
                 api.nvim_echo({{
@@ -63,7 +63,6 @@ local function buf_kill(range, force, wipeout)
                 cmd.echo('""')
                 cmd.redraw()
             end
-
         end
     end
 


### PR DESCRIPTION
This PR changes the behavior of pressing escape when prompted for changes. Currently, the behavior of escape acts like ignore, allowing the buffer to be closed. This changes the behavior so that it acts like cancel.

Resolves #32

It's a quick hack and may be considered somewhat of a breaking change if folks were accustomed to pressing any key to close. 