### PR TITLE
Don't switch to special buffers such as quickfix

### DIFF
--- a/lua/bufdelete/init.lua
+++ b/lua/bufdelete/init.lua
@@ -93,7 +93,7 @@ local function buf_kill(target_buffers, force, wipeout)
     -- Get list of valid and listed buffers that will not be deleted
     local undeleted_buffers = vim.tbl_filter(
         function(buf)
-            return api.nvim_buf_is_valid(buf) and bo[buf].buflisted and not buf_is_deleted[buf]
+            return api.nvim_buf_is_valid(buf) and bo[buf].buflisted and not buf_is_deleted[buf] and bo[buf].buftype == ''
         end,
         api.nvim_list_bufs()
     )


### PR DESCRIPTION
I was looking for a way to avoid the quickfix window from taking my screen after deleting the last buffer, I thought there could be other cases where this can happen for other buflisted buffers that are not quickfix, so I ended up checking if buftype is empty before deciding to switch to it. Do you have a better solution to this? Perhaps expose this as a config?