### PR TITLE
Utilize nvim_buf_is_loaded for more accurate buffer validation

### DIFF
--- a/lua/bufdelete/init.lua
+++ b/lua/bufdelete/init.lua
@@ -137,8 +137,8 @@ local function buf_kill(target_buffers, switchable_buffers, force, wipeout)
 
     -- Close all target buffers one by one.
     for bufnr, _ in pairs(buf_is_deleted) do
-        -- Check if buffer is still valid as it may be deleted due to options like bufhidden=wipe.
-        if api.nvim_buf_is_valid(bufnr) then
+        -- Check if buffer is still valid and loaded as it may be deleted due to options like bufhidden=wipe.
+        if api.nvim_buf_is_loaded(bufnr) then
             -- Only use force if buffer is modified, is a terminal or if `force` is true.
             local use_force = force or bo[bufnr].modified or bo[bufnr].buftype == 'terminal'
 


### PR DESCRIPTION
In the case of an unloaded buffer, the function `nvim_buf_is_valid` returns true, but calling `bdelete` with an unloaded buffer is invalid.

Therefore, we should switch to the `api.nvim_buf_is_loaded` function, which checks both that the buffer is valid and loaded.

This PR fix https://github.com/famiu/bufdelete.nvim/issues/52